### PR TITLE
이미지 처리 중 발생하던 에러 처리

### DIFF
--- a/main.py
+++ b/main.py
@@ -92,15 +92,16 @@ def binary(url, model):
     
     image_width = 180
     image_height = 180
+
     is_ad = 0
     not_ad = 0
+
     X = []
     cropped_images = []
 
-    preprocess_result_type = ["ad", "non-ad", "path-error", "open-size-zero-error", "open-none-error", "small-image-error"];
-
     binary_image_data = image_to_binary(url)
-    if (binary_image_data in preprocess_result_type):
+
+    if (binary_image_data == "ad" or binary_image_data == "non-ad"):
         return binary_image_data
 
     image_nparray = np.asarray(binary_image_data, dtype=np.uint8)
@@ -151,16 +152,16 @@ def binary(url, model):
 @app.route("/",methods=['GET','POST'])
 def check():
     if request.method=='POST':
-        url = request.get_json()['url']
-        result = binary(url, model)
-        response_body = {"class": result}
-        response = json.dumps(response_body, ensure_ascii=False)
-
-        if (result.endswith("error")):
-            return response, 500
-        else:
+        try:
+            url = request.get_json()['url']
+            result = binary(url, model)
+            response_body = {"class": result}
+            response = json.dumps(response_body, ensure_ascii=False)
             return response, 200
-    return "error", 405
+        except Exception as e:
+            print(e)
+            return "Internal Server Error", 500
+    return "Method Not Allowed", 405
 
 if __name__ == '__main__':
     app.run(debug=False, host= '0.0.0.0', port='3000')

--- a/main.py
+++ b/main.py
@@ -159,14 +159,6 @@ def check():
         else:
             return response, 200
         
-        # if result == "ad":           ## result 수정
-        #     config = {"class": "ad"}
-
-        # else:
-        #     config = {"class": "non-ad"}
-
-        # result = json.dumps(config, ensure_ascii=False)
-        
         return result
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -167,9 +167,8 @@ def binary(url, model):
         
 @app.route("/",methods=['GET','POST'])
 def check():
-    if request.method=='GET':
-        
-        url = request.args.get('url')
+    if request.method=='POST':
+        url = request.get_json()['url']
         result = binary(url, model)
         response_body = {"class": result}
         response = json.dumps(response_body, ensure_ascii=False)
@@ -178,8 +177,7 @@ def check():
             return response, 500
         else:
             return response, 200
-        
-        return result
+    return "error", 405
 
 if __name__ == '__main__':
     app.run(debug=False, host= '0.0.0.0', port='3000')

--- a/main.py
+++ b/main.py
@@ -65,11 +65,11 @@ Returns :
     "path-error" : url 경로 에러 -> Error
 """
 def image_open(url):
-    if (url.endswith(".gif")):
+    if (".gif" in url):
         # 이미지가 gif 형식일 경우 -> 제거한다.
         # 형식 변환을 할 수 있을지 찾아보기
         return "ad"
-    if (url.endswith(".svg")):
+    if (".svg" in url):
         # 이미지가 svg 형식일 경우 -> 기호일 가능성이 높으므로 제거하지 않는다.
         return "non-ad"
     # 이 외의 경우에는 이미지를 가져온다.
@@ -78,9 +78,7 @@ def image_open(url):
         if (url.startswith("data:image")):
             encoded_data = url.split(',')[1].replace(" ", "").replace("\n", "")
             if (len(encoded_data) % 4 != 0):
-                print("🥳 : ", len(encoded_data) , " : ", len(encoded_data) % 4)
                 encoded_data += "=" * (4 - len(encoded_data) % 4)
-                print("✅ : ", len(encoded_data) , " : ", len(encoded_data) % 4)
             image_data = base64.b64decode(encoded_data)
             image = Image.open(io.BytesIO(image_data))
             return image
@@ -88,12 +86,9 @@ def image_open(url):
         image = requests.get(url, verify=False).content
         return image
     except Exception as e:
-        print("ERROR : ", e)
         if (str(e).startswith("cannot identify image file")):
             # 비어있거나 열 수 없는 이미지 파일인 경우 -> 제거하지 않는다.
             return "non-ad"
-        elif (str(e).startswith("Invalid base64-encoded string:")):
-            print("💦 : ", len(encoded_data) , " : ", len(encoded_data) % 4)
         return "path-error"
 
 def binary(url, model):

--- a/main.py
+++ b/main.py
@@ -16,7 +16,10 @@ import numpy as np
 import cv2
 import urllib.request
 import requests
-from io import BytesIO
+# from io import BytesIO
+import io
+import base64
+from PIL import Image
 
 import urllib3
 # InsecureRequestWarning 경고 제거
@@ -71,9 +74,16 @@ def image_open(url):
         return "non-ad"
     # 이 외의 경우에는 이미지를 가져온다.
     try:
+        # data:image 형식의 이미지를 가져오는 경우
+        if (url.startswith("data:image")):
+            encoded_data = url.split(',')[1]
+            image_data = base64.b64decode(encoded_data)
+            image = Image.open(io.BytesIO(image_data))
+            return image
+        # 일반적인 url 형식의 이미지를 가져오는 경우
         image = requests.get(url, verify=False).content
         return image
-    except:
+    except Exception as e:
         return "path-error"
 
 def binary(url, model):

--- a/main.py
+++ b/main.py
@@ -76,7 +76,11 @@ def image_open(url):
     try:
         # data:image 형식의 이미지를 가져오는 경우
         if (url.startswith("data:image")):
-            encoded_data = url.split(',')[1]
+            encoded_data = url.split(',')[1].replace(" ", "").replace("\n", "")
+            if (len(encoded_data) % 4 != 0):
+                print("🥳 : ", len(encoded_data) , " : ", len(encoded_data) % 4)
+                encoded_data += "=" * (4 - len(encoded_data) % 4)
+                print("✅ : ", len(encoded_data) , " : ", len(encoded_data) % 4)
             image_data = base64.b64decode(encoded_data)
             image = Image.open(io.BytesIO(image_data))
             return image
@@ -84,9 +88,12 @@ def image_open(url):
         image = requests.get(url, verify=False).content
         return image
     except Exception as e:
+        print("ERROR : ", e)
         if (str(e).startswith("cannot identify image file")):
             # 비어있거나 열 수 없는 이미지 파일인 경우 -> 제거하지 않는다.
             return "non-ad"
+        elif (str(e).startswith("Invalid base64-encoded string:")):
+            print("💦 : ", len(encoded_data) , " : ", len(encoded_data) % 4)
         return "path-error"
 
 def binary(url, model):

--- a/main.py
+++ b/main.py
@@ -69,22 +69,22 @@ def binary(url, model):
             image_nparray = np.asarray(bytearray(requests.get(url, verify=False).content), dtype=np.uint8)
         # 이미지 경로가 잘못된 경우 제거한다.
         except:
-            return "ad"
+            return "path-error"
         
     # 보안 문제로 인해 열리지 않는 경우 제거
     if image_nparray.size == 0:
-        return "ad"
+        return "open-size-zero-error"
     
     # binary 형태로 읽은 파일을 decode -> 1D-array에서 3D-array로 변경
     image_bgr = cv2.imdecode(image_nparray, cv2.IMREAD_COLOR)
     
     # 보안 문제로 인해 열리지 않는 경우 제거
     if image_bgr is None:
-        return "ad"
+        return "open-none-error"
 
     # 이미지가 너무 작은 경우 -> 무조건 제거한다.
     if image_bgr.shape[0] < 64 | image_bgr.shape[1] < 64:
-        return "ad"
+        return "small-image-error"
 
     
     # BGR에서 RGB로 변경
@@ -124,16 +124,25 @@ def check():
         
         url = request.args.get('url')
         result = binary(url, model)
-        
-        if result == "ad":           ## result 수정
-            config = {"class": "ad"}
 
+        if (result.endswith("error")):
+            config = {"class": result}
+            response = json.dumps(config, ensure_ascii=False)
+            return response, 500
         else:
-            config = {"class": "non-ad"}
+            config = {"class": result}
+            response = json.dumps(config, ensure_ascii=False)
+            return response, 200
+        
+        # if result == "ad":           ## result 수정
+        #     config = {"class": "ad"}
 
-        result = json.dumps(config, ensure_ascii=False)
+        # else:
+        #     config = {"class": "non-ad"}
+
+        # result = json.dumps(config, ensure_ascii=False)
         
         return result
 
 if __name__ == '__main__':
-    app.run(debug=False, host= '0.0.0.0', port='5000')
+    app.run(debug=False, host= '0.0.0.0', port='3000')

--- a/main.py
+++ b/main.py
@@ -92,10 +92,10 @@ def image_to_binary(url):
         return bytearray(image)
     
     except Exception as e:
-        if (str(e).startswith("cannot identify image file")):
-            # 비어있거나 열 수 없는 이미지 파일인 경우 -> 제거하지 않는다.
-            return "non-ad"
-        return "path-error"
+        # 비어있거나 열 수 없는 이미지 파일인 경우 -> 제거하지 않는다. (path-error)
+        # data:image 형식의 이미지에서 열 수 없는 경우가 있음
+        # 잘못된 경로를 입력하는 경우는 아직 발견되지 않음.
+        return "non-ad"
 
 def binary(url, model):
     

--- a/main.py
+++ b/main.py
@@ -84,6 +84,9 @@ def image_open(url):
         image = requests.get(url, verify=False).content
         return image
     except Exception as e:
+        if (str(e).startswith("cannot identify image file")):
+            # 비어있거나 열 수 없는 이미지 파일인 경우 -> 제거하지 않는다.
+            return "non-ad"
         return "path-error"
 
 def binary(url, model):

--- a/main.py
+++ b/main.py
@@ -164,4 +164,4 @@ def check():
     return "Method Not Allowed", 405
 
 if __name__ == '__main__':
-    app.run(debug=False, host= '0.0.0.0', port='3000')
+    app.run(debug=False, host= '0.0.0.0', port='5000')

--- a/main.py
+++ b/main.py
@@ -131,9 +131,9 @@ def binary(url, model):
     if image_bgr is None:
         return "non-ad"
 
-    # 이미지가 너무 작은 경우 -> 무조건 제거한다.
+    # 이미지가 너무 작은 경우 -> 제거하지 않는다. (small-image-error)
     if image_bgr.shape[0] < 64 | image_bgr.shape[1] < 64:
-        return "small-image-error"
+        return "non-ad"
 
     
     # BGR에서 RGB로 변경

--- a/main.py
+++ b/main.py
@@ -126,9 +126,10 @@ def binary(url, model):
     # binary 형태로 읽은 파일을 decode -> 1D-array에서 3D-array로 변경
     image_bgr = cv2.imdecode(image_nparray, cv2.IMREAD_COLOR)
     
-    # 보안 문제로 인해 열리지 않는 경우 제거
+    # 이미지가 확인되지 않는 경우 -> 제거하지 않는다. (open-none-error)
+    # 몇몇 url에서 이미지가 아니거나, 1*1 픽셀의 이미지를 가져오는 경우가 있음
     if image_bgr is None:
-        return "open-none-error"
+        return "non-ad"
 
     # 이미지가 너무 작은 경우 -> 무조건 제거한다.
     if image_bgr.shape[0] < 64 | image_bgr.shape[1] < 64:

--- a/main.py
+++ b/main.py
@@ -151,14 +151,12 @@ def check():
         
         url = request.args.get('url')
         result = binary(url, model)
+        response_body = {"class": result}
+        response = json.dumps(response_body, ensure_ascii=False)
 
         if (result.endswith("error")):
-            config = {"class": result}
-            response = json.dumps(config, ensure_ascii=False)
             return response, 500
         else:
-            config = {"class": result}
-            response = json.dumps(config, ensure_ascii=False)
             return response, 200
         
         # if result == "ad":           ## result 수정

--- a/main.py
+++ b/main.py
@@ -118,9 +118,10 @@ def binary(url, model):
     # ?
     image_nparray = np.asarray(binary_image_data, dtype=np.uint8)
         
-    # 보안 문제로 인해 열리지 않는 경우 제거
+    # 응답이 204 No Content인 경우 -> 제거하지 않는다. (open-size-zero-error)
+    # google adsense에서 가져온 이미지가 204 No Content인 경우가 있음
     if image_nparray.size == 0:
-        return "open-size-zero-error"
+        return "non-ad"
     
     # binary 형태로 읽은 파일을 decode -> 1D-array에서 3D-array로 변경
     image_bgr = cv2.imdecode(image_nparray, cv2.IMREAD_COLOR)


### PR DESCRIPTION
### 변경된 사항

변경 사항에 대한 자세한 내용은 [🔗 노션](https://suave-fascinator-d1f.notion.site/f36796e733a94e62a4d1dd4533990585?pvs=4) 참고해주기!

- 요청 메소드를 기존 `GET`에서 `POST`로 변경 (이미지 url 손상 방지용)
- url로부터 이미지를 여는 로직이 복잡해져서 `image_to_binary` 함수로 분리하여 이미지를 열고, `bytearray` 형태로 바꾸는 작업까지 수행함.
- status code 405, 500 응답 추가
- 기본적으로 에러가 나는 경우에 `non-ad` 를 반환하도록 수정함
- `data:image` 형식의 이미지를 가져오는 로직 추가 (`path-error`의 원인이었음)

### 다음 주에 논의해봐야 할 것 

- 에러가 나는 경우에 지금과 달리 `ad` 로 처리하여 제거해야 하는 경우가 있는지
- 메모리에 저장하지 않고 gif를 jpg, jpeg, png로 변환할 수 있는 방법이 있는지
- 모델의 판단 결과만을 광고 제거에 사용할것인지, 아니면 이미지 처리가 불가능한 경우 한정으로 기존의 광고 제거 방식 (url 필터링) 을 활용할것인지